### PR TITLE
fix precedence

### DIFF
--- a/src/components/common/generated-avatar.tsx
+++ b/src/components/common/generated-avatar.tsx
@@ -16,7 +16,7 @@ export default function GeneratedAvatar({
   variant,
   options,
 }: GeneratedAvatarProps) {
-  const baseOptions = { seed, ...options };
+  const baseOptions = { ...options, seed };
   let avatar;
 
   if (variant === 'avataaarsNeutral') {


### PR DESCRIPTION
Updated the spread order so the explicit seed prop always takes precedence, preventing accidental overrides and keeping avatar generation deterministic.

fixes #4 