### PR TITLE
fix dimensions mismatch 

### DIFF
--- a/src/components/home/zephyr-popup.tsx
+++ b/src/components/home/zephyr-popup.tsx
@@ -101,8 +101,8 @@ export function ZephyrPopup({ open, onOpenChange }: ZephyrPopupProps) {
                   <Image
                     src="/zephyr-logo.svg"
                     alt="Zephyr Logo"
-                    width={36}
-                    height={36}
+                    width={80}
+                    height={80}
                     className="mx-auto mb-8 size-20"
                   />
                 </motion.div>


### PR DESCRIPTION
Fixed the mismatch between Next.js Image dimensions and Tailwind sizing to prevent unintended scaling and layout issues. Fixes #7 