### PR TITLE
fix typos in apiStatus, apiEndpoints, and admin login

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -117,7 +117,7 @@ export const apiEndPoints = {
   },
 
   codingQuestionRoutes: {
-    createCodingQuestion: '/problems/create//coding-question',
+    createCodingQuestion: '/problems/create/coding-question',
     getAllCodingQuestions: '/problems',
     getCodingQuestionsByContest: (contestId: string) => `/problems/${contestId}`,
     updateCodingQuestion: (id: string) => `/problems/update/coding-question/${id}`,

--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -125,7 +125,7 @@ export const apiEndPoints = {
   },
 
   testCases: {
-    createTestCase: '/contest/crate-testcase',
+    createTestCase: '/contest/create-testcase',
     getAllTestCasesForProblem: (contestProblemId: string) => `/contest/all/${contestProblemId}`,
     updateTestCase: (id: string) => `/contest/update-testcase/${id}`,
     deleteTestCase: (id: string) => `/contest/delete-testcase/${id}`,

--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -83,7 +83,7 @@ export const apiEndPoints = {
 
   option: {
     createOption: '/options/create-option',
-    getOptionsByQuestion: (questionId: string) => `/options/option-quesition/${questionId}`,
+    getOptionsByQuestion: (questionId: string) => `/options/option-question/${questionId}`,
     getOptionById: (id: string) => `/options/${id}`,
     updateOption: (id: string) => `/options/update-option/${id}`,
     deleteOption: (id: string) => `/options/delete-option/${id}`,

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -86,7 +86,7 @@ export default function Login() {
                 name="password"
                 type={showPassword ? 'string' : 'password'}
                 label="Password"
-                placeholder="Enter your email"
+                placeholder="Enter your password"
                 isAsterisk
               />
               <Icon

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -25,7 +25,7 @@ export default function Login() {
   const router = useRouter();
 
   const adminLoginSchema = z.object({
-    email: z.string().email('Please entear a valid email address!'),
+    email: z.string().email('Please enter a valid email address!'),
     password: z.string().min(1, 'Password is required!'),
   });
 

--- a/src/constants/apiStatus.ts
+++ b/src/constants/apiStatus.ts
@@ -5,7 +5,7 @@ const NoContent204 = 204;
 const BadRequest400 = 400;
 const Unauthorized401 = 401;
 const Forbidden403 = 403;
-const NotFount404 = 404;
+const NotFound404 = 404;
 const ServerError500 = 500;
 const Conflict409 = 409;
 
@@ -17,7 +17,7 @@ export const statusCode = {
   BadRequest400,
   Unauthorized401,
   Forbidden403,
-  NotFount404,
+  NotFound404,
   ServerError500,
   Conflict409,
 };


### PR DESCRIPTION
hey, i fixed the typos mentioned in issue #36:

- apiStatus.ts: NotFount404 -> NotFound404
- apiEndpoints.ts: option-quesition -> option-question
- apiEndpoints.ts: fixed double slash in createCodingQuestion endpoint
- apiEndpoints.ts: crate-testcase -> create-testcase
- admin login: entear -> enter in validation message
- admin login: fixed password placeholder (was showing email)

let me know if anything needs changing 👍