### PR TITLE
fix: correct NotFount404 typo to NotFound404

### DIFF
--- a/src/constants/apiStatus.ts
+++ b/src/constants/apiStatus.ts
@@ -5,7 +5,7 @@ const NoContent204 = 204;
 const BadRequest400 = 400;
 const Unauthorized401 = 401;
 const Forbidden403 = 403;
-const NotFount404 = 404;
+const NotFound404 = 404;
 const ServerError500 = 500;
 const Conflict409 = 409;
 
@@ -17,7 +17,7 @@ export const statusCode = {
   BadRequest400,
   Unauthorized401,
   Forbidden403,
-  NotFount404,
+  NotFound404,
   ServerError500,
   Conflict409,
 };


### PR DESCRIPTION
Fixes #36.

`NotFount404` was a misspelling of `NotFound404`. This renames both the constant declaration and its entry in the exported `statusCode` object so the HTTP 404 status is named correctly.

I ran a repo-wide code search for `NotFount404` and it appears **only** in `src/constants/apiStatus.ts`, so nothing else references the old name and no usages break.